### PR TITLE
Fix latitude and longitude fields

### DIFF
--- a/src/parser/diningParser.ts
+++ b/src/parser/diningParser.ts
@@ -68,8 +68,8 @@ export default class DiningParser {
     const atIndex = link.indexOf("@");
     const locationUrl = link.slice(atIndex + 1, link.length);
     const commaIndex = locationUrl.indexOf(",");
-    const latitude = locationUrl.slice(commaIndex + 1, locationUrl.length);
-    const longitude = locationUrl.slice(0, commaIndex);
+    const latitude = locationUrl.slice(0, commaIndex);
+    const longitude = locationUrl.slice(commaIndex + 1, locationUrl.length);
     return [parseFloat(latitude), parseFloat(longitude)];
   }
 


### PR DESCRIPTION

# Description

Fix a bug where the latitude and longitude fields are mixed up in the API results.

Closes ScottyLabs/cmueats#27

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually by running the API locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
