### PR TITLE
Added initial Tapingo links

### DIFF
--- a/src/containers/locationBuilder.ts
+++ b/src/containers/locationBuilder.ts
@@ -8,6 +8,7 @@ export interface ILocation {
   shortDescription?: string;
   description?: string;
   url?: string;
+  tapingoLink?: string;
   menu?: string;
   location?: string;
   coordinates?: Coordinate;
@@ -40,6 +41,7 @@ export default class LocationBuilder {
   private shortDescription?: string;
   private description?: string;
   private url?: string;
+  private tapingoLink?: string;
   private location?: string;
   private menu?: string;
   private coordinates?: Coordinate;
@@ -92,6 +94,11 @@ export default class LocationBuilder {
     return this;
   }
 
+  setTapingoLink(tapingoLink: string) {
+    this.tapingoLink = tapingoLink;
+    return this;
+  }
+
   setTimes(times: TimeSchema[]) {
     this.times = times;
     return this;
@@ -122,6 +129,7 @@ export default class LocationBuilder {
       shortDescription: this.shortDescription,
       description: this.description,
       url: this.url,
+      tapingoLink: this.tapingoLink,
       location: this.location,
       menu: this.menu,
       coordinates: this.coordinates,

--- a/src/overwrites/locationOverwrites.ts
+++ b/src/overwrites/locationOverwrites.ts
@@ -5,7 +5,7 @@ type LocationOverwrites = {
 };
 
 /**
- * Dining locations coordinates that we manually overwrite because they are
+ * Dining location coordinates that we manually overwrite because they are
  * wrong on the dining API.
  */
 const overwrites: LocationOverwrites = {

--- a/src/overwrites/tapingoOverwrites.ts
+++ b/src/overwrites/tapingoOverwrites.ts
@@ -3,8 +3,8 @@ type TapingoOverwrites = {
 };
 
 /**
- * Dining locations Grubhub Links that we manually overwrite to provide
- * ordering on CMUEats.
+ * Dining locations Tapingo Links that we manually overwrite to provide
+ * Grubhub menu previews on CMUEats.
  */
 const tapingoOverwrites: TapingoOverwrites = {
   'AU BON PAIN AT SKIBO CAFÉ': 'https://kioskweb.tapingo.com/#5954818',

--- a/src/overwrites/tapingoOverwrites.ts
+++ b/src/overwrites/tapingoOverwrites.ts
@@ -3,7 +3,7 @@ type TapingoOverwrites = {
 };
 
 /**
- * Dining locations Tapingo Links that we manually overwrite to provide
+ * Dining location Tapingo links that we manually overwrite to provide
  * Grubhub menu previews on CMUEats.
  */
 const tapingoOverwrites: TapingoOverwrites = {

--- a/src/overwrites/tapingoOverwrites.ts
+++ b/src/overwrites/tapingoOverwrites.ts
@@ -1,0 +1,15 @@
+type TapingoOverwrites = {
+  [conceptName: string]: string;
+};
+
+/**
+ * Dining locations Grubhub Links that we manually overwrite to provide
+ * ordering on CMUEats.
+ */
+const tapingoOverwrites: TapingoOverwrites = {
+  'AU BON PAIN AT SKIBO CAFÉ': 'https://kioskweb.tapingo.com/#5954818',
+  'EL GALLO DE ORO': 'https://kioskweb.tapingo.com/#6013799',
+  'DE FER COFFEE & TEA AT MAGGIE MURPH CAFÉ': 'https://kioskweb.tapingo.com/#8914187',
+};
+
+export default tapingoOverwrites;

--- a/src/parser/diningParser.ts
+++ b/src/parser/diningParser.ts
@@ -7,6 +7,7 @@ import SpecialsBuilder, {
   SpecialSchema,
 } from "../containers/specials/specialsBuilder";
 import locationOverwrites from "../overwrites/locationOverwrites";
+import tapingoOverwrites from "../overwrites/tapingoOverwrites";
 
 /**
  * Retrieves the HTML from the CMU Dining website and parses the information
@@ -78,6 +79,7 @@ export default class DiningParser {
     const conceptHTML = await getHTMLResponse(new URL(conceptLink));
     const $ = load(conceptHTML);
     builder.setURL(conceptLink);
+    builder.setTapingoLink(tapingoOverwrites[builder.getName()!]);
     const description = $("div.description p").text().trim();
     builder.setDesc(description);
 


### PR DESCRIPTION
These could act as previews for the Grubhub locations with a 'Show Grubhub Menu Preview' button. CMUEats-wise, we could add instructions on a FAQ page (see https://www.cmu.edu/dining/your-dining-plan/grubhub.html) to order on Grubhub since Grubhub doensn't have campus dining on the website only app.