### PR TITLE
fix: location info for 202 and 168

### DIFF
--- a/src/overwrites/locationCoordinateOverwrites.ts
+++ b/src/overwrites/locationCoordinateOverwrites.ts
@@ -129,6 +129,14 @@ const locationCoordinateOverwrites: ILocationCoordinateOverwrites = {
     lat: 40.44414285761781,
     lng: -79.93888579754876,
   },
+  "202": {
+    lat: 40.44253638019975,
+    lng: -79.94032253558025,
+  },
+  "168": {
+    lat: 40.44283900428467,
+    lng: -79.94133909281383,
+  },
 };
 
 export default locationCoordinateOverwrites;


### PR DESCRIPTION
Fix the location coordinates for Fire & Stone (No. 202) and Tartan Express Food Truck (No. 168) as they are wrongly displayed. 

![teft](https://github.com/user-attachments/assets/1f6dd024-ded2-4e49-a878-bc68b274b4cb)
![fas](https://github.com/user-attachments/assets/a56f81ef-5678-45f0-b62f-054b662a5b38)

Updated: 

![update](https://github.com/user-attachments/assets/2fa02976-f7a0-4aab-9031-fd572baa304e)
